### PR TITLE
Proposer deux nouvelles touches au clavier : "et" tironien et point median

### DIFF
--- a/Clavier/CremmaLab.json
+++ b/Clavier/CremmaLab.json
@@ -217,6 +217,30 @@
             "keyboard_code": null,
             "column": 4,
             "row": 4
+        },
+
+        {
+            "character": "\u00B7",
+            "legend" : "median point",
+            "keyboard_code": null,
+            "column": 5,
+            "row": 4
+        },
+
+        {
+            "character": "\u00B7",
+            "legend" : "median point",
+            "keyboard_code": null,
+            "column": 5,
+            "row": 4
+        },
+
+        {
+            "character": "\u204a",
+            "legend" : "et tironien",
+            "keyboard_code": null,
+            "column": 5,
+            "row": 5
         }
 
        


### PR DESCRIPTION
J'ai apporté une suggestion de modification au fichier [lien vers le fichier CremmaLab.json](https://github.com/Piraxe/HN-2023-Nevers/blob/main/Clavier/CremmaLab.json).
Les modifications comprennent l'ajout de deux nouveaux caractères Unicode pour enrichir la fonctionnalité du clavier : le "et" tironien et le point médian. Ces dernières visent à permettre de transcrire ces deux signes présents dans les folios de notre manuscrit.
J'ai également vérifié que ces deux modifications respectent les normes de codage et la cohérence du fichier JSON. J'ai testé ces modifications localement pour m'assurer qu'elles fonctionnent correctement (essai fait sur E-scriptorium).

